### PR TITLE
fix #4 - 예외 처리 클래스 수정

### DIFF
--- a/src/main/java/com/wanted/teamV/exception/CustomException.java
+++ b/src/main/java/com/wanted/teamV/exception/CustomException.java
@@ -11,11 +11,11 @@ import org.springframework.http.HttpStatus;
 public class CustomException extends RuntimeException {
     private ErrorCode errorCode;
     private String message;
-    private HttpStatus httpStatus;
+    private HttpStatus status;
 
     public CustomException(ErrorCode errorCode) {
         this.errorCode = errorCode;
         this.message = errorCode.getMessage();
-        this.httpStatus = errorCode.getStatus();
+        this.status = errorCode.getStatus();
     }
 }

--- a/src/main/java/com/wanted/teamV/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/wanted/teamV/exception/GlobalExceptionHandler.java
@@ -17,25 +17,29 @@ import static com.wanted.teamV.exception.ErrorCode.INVALID_REQUEST;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<?> handleCustomException(CustomException e) {
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
         ErrorResponse response = ErrorResponse.builder()
+                .errorCode(e.getErrorCode())
                 .message(e.getMessage())
                 .build();
+
         log.warn("{} is occurred.", e.getMessage());
-        return new ResponseEntity<>(response, e.getHttpStatus());
+        return ResponseEntity.status(e.getStatus()).body(response);
     }
 
     @ExceptionHandler(Exception.class)
-    public ErrorResponse handleException(Exception e) {
-        log.error("Exception is occurred.", e);
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .errorCode(INTERNAL_SERVER_ERROR)
+                .message(INTERNAL_SERVER_ERROR.getMessage())
+                .build();
 
-        return new ErrorResponse(
-                INTERNAL_SERVER_ERROR,
-                INTERNAL_SERVER_ERROR.getMessage());
+        log.error("Exception is occurred.", e);
+        return ResponseEntity.status(response.getErrorCode().getStatus()).body(response);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         BindingResult bindingResult = e.getBindingResult();
         StringBuilder errorMessage = new StringBuilder();
 
@@ -43,16 +47,24 @@ public class GlobalExceptionHandler {
             errorMessage.append(fieldError.getDefaultMessage()).append("; ");
         }
 
+        ErrorResponse response = ErrorResponse.builder()
+                .errorCode(INVALID_REQUEST)
+                .message(errorMessage.toString())
+                .build();
+
         log.error("MethodArgumentNotValidException is occurred.", e);
-        return ResponseEntity.badRequest().body(
-                new ErrorResponse(INVALID_REQUEST, INVALID_REQUEST.getMessage()));
+        return ResponseEntity.status(response.getErrorCode().getStatus()).body(response);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<?> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .errorCode(INVALID_REQUEST)
+                .message(INVALID_REQUEST.getMessage())
+                .build();
+
         log.error("DataIntegrityViolationException is occurred.", e);
-        return ResponseEntity.badRequest().body(
-                new ErrorResponse(INVALID_REQUEST, INVALID_REQUEST.getMessage()));
+        return ResponseEntity.status(response.getErrorCode().getStatus()).body(response);
     }
 
 }


### PR DESCRIPTION
### 변경사항
**AS-IS**

- INTERNAL_SERVER_ERROR 상황에서 응답 상태 코드가 200으로 반환
- handleException 메서드의 반환 형식이 다른 메서드들과 다름

**TO-BE** 

- INTERNAL_SERVER_ERROR 상황에서 응답 상태 코드가 200으로 반환되는 문제 해결
- 모든 메서드의 반환형식을 ResponseEntity<ErrorResponse>로 통일
- ErrorResponse의 errorCode를 통해 올바른 상태 코드를 가져와서 사용하도록 수정
- body에는 errorCode와 message 출력

### 테스트
- [ ] 테스트 코드
- [ ] API 테스트
