### PR TITLE
Feat/#10 - 통계 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
-	implementation 'com.querydsl:querydsl-jpa'
-	annotationProcessor "com.querydsl:querydsl-apt"
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
@@ -40,12 +40,12 @@ def generated = 'src/main/generated'
 
 // querydsl QClass 파일 생성 위치를 지정
 tasks.withType(JavaCompile) {
-	options.getGeneratedSourceOutputDirectory().set(file(generated))
+	options.generatedSourceOutputDirectory = file(generated)
 }
 
 // java source set 에 querydsl QClass 위치 추가
 sourceSets {
-	main.java.srcDirs += [ generated ]
+	main.java.srcDirs += "$projectDir/build/generated"
 }
 
 // gradle clean 시에 QClass 디렉토리 삭제

--- a/src/main/java/com/wanted/teamV/config/QueryDslConfig.java
+++ b/src/main/java/com/wanted/teamV/config/QueryDslConfig.java
@@ -2,15 +2,19 @@ package com.wanted.teamV.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
-import org.springframework.beans.factory.annotation.Autowired;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RequiredArgsConstructor
 public class QueryDslConfig {
-/*    @Autowired private EntityManager entityManager;
+    @PersistenceContext
+    private final EntityManager entityManager;
+
     @Bean
     public JPAQueryFactory jpaQueryFactory(){
         return new JPAQueryFactory(entityManager);
-    }*/
+    }
 }

--- a/src/main/java/com/wanted/teamV/config/WebConfig.java
+++ b/src/main/java/com/wanted/teamV/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.wanted.teamV.config;
 
+import com.wanted.teamV.type.converter.StringToStatisticsSortTypeConverter;
 import com.wanted.teamV.type.converter.StringToStatisticsTimeTypeConverter;
 import com.wanted.teamV.type.converter.StringToStatisticsValueTypeConverter;
 import org.springframework.context.annotation.Configuration;
@@ -12,5 +13,6 @@ public class WebConfig implements WebMvcConfigurer {
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new StringToStatisticsValueTypeConverter());
         registry.addConverter(new StringToStatisticsTimeTypeConverter());
+        registry.addConverter(new StringToStatisticsSortTypeConverter());
     }
 }

--- a/src/main/java/com/wanted/teamV/config/WebConfig.java
+++ b/src/main/java/com/wanted/teamV/config/WebConfig.java
@@ -1,0 +1,16 @@
+package com.wanted.teamV.config;
+
+import com.wanted.teamV.type.converter.StringToStatisticsTimeTypeConverter;
+import com.wanted.teamV.type.converter.StringToStatisticsValueTypeConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToStatisticsValueTypeConverter());
+        registry.addConverter(new StringToStatisticsTimeTypeConverter());
+    }
+}

--- a/src/main/java/com/wanted/teamV/config/WebConfig.java
+++ b/src/main/java/com/wanted/teamV/config/WebConfig.java
@@ -1,18 +1,32 @@
 package com.wanted.teamV.config;
 
+import com.wanted.teamV.controller.AuthenticationPrincipalArgumentResolver;
 import com.wanted.teamV.type.converter.StringToStatisticsSortTypeConverter;
 import com.wanted.teamV.type.converter.StringToStatisticsTimeTypeConverter;
 import com.wanted.teamV.type.converter.StringToStatisticsValueTypeConverter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
+
     @Override
     public void addFormatters(FormatterRegistry registry) {
         registry.addConverter(new StringToStatisticsValueTypeConverter());
         registry.addConverter(new StringToStatisticsTimeTypeConverter());
         registry.addConverter(new StringToStatisticsSortTypeConverter());
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationPrincipalArgumentResolver);
     }
 }

--- a/src/main/java/com/wanted/teamV/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamV/controller/StatisticsController.java
@@ -1,0 +1,48 @@
+package com.wanted.teamV.controller;
+
+import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.exception.CustomException;
+import com.wanted.teamV.exception.ErrorCode;
+import com.wanted.teamV.service.StatisticsService;
+import com.wanted.teamV.type.StatisticsTimeType;
+import com.wanted.teamV.type.StatisticsValueType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/statistics")
+@RequiredArgsConstructor
+public class StatisticsController {
+    private final StatisticsService statisticsService;
+
+    @GetMapping
+    public ResponseEntity<List<StatisticsResDto>> getStatistics(
+        @RequestParam(required = false) String hashtag,
+        @RequestParam StatisticsTimeType type,
+        @RequestParam(required = false) LocalDate start,
+        @RequestParam(required = false) LocalDate end,
+        @RequestParam(required = false, defaultValue = "count") StatisticsValueType value
+    ) {
+
+        if (hashtag == null || hashtag.isBlank()) {
+            // TODO - JWT 토큰에서 본인 계정 불러오기
+            hashtag = "맛집";
+        }
+        if (start == null) {
+            start = LocalDate.now().minusDays(7);
+        }
+        if (end == null) {
+            end = LocalDate.now();
+        }
+
+        List<StatisticsResDto> responses =
+                statisticsService.getCountsForEachTimeByHashtag(hashtag, type, start, end, value);
+
+        return ResponseEntity.ok(responses);
+    }
+
+}

--- a/src/main/java/com/wanted/teamV/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamV/controller/StatisticsController.java
@@ -1,6 +1,8 @@
 package com.wanted.teamV.controller;
 
 import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.exception.CustomException;
+import com.wanted.teamV.exception.ErrorCode;
 import com.wanted.teamV.service.StatisticsService;
 import com.wanted.teamV.type.StatisticsSortType;
 import com.wanted.teamV.type.StatisticsTimeType;
@@ -10,12 +12,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 @RestController
 @RequestMapping("/statistics")
 @RequiredArgsConstructor
 public class StatisticsController {
+
+    private static final int MAX_DATE_PERIOD = 31;
+    private static final int MAX_HOUR_PERIOD = 7;
+
     private final StatisticsService statisticsService;
 
     @GetMapping
@@ -33,17 +40,35 @@ public class StatisticsController {
             // TODO - JWT 토큰에서 본인 계정 불러오기
             hashtag = "맛집";
         }
-        if (startDate == null) {
-            startDate = LocalDate.now().minusDays(7);
-        }
-        if (endDate == null) {
+
+        if (startDate == null && endDate == null) {
+            startDate = LocalDate.now().minusDays(MAX_HOUR_PERIOD -1);
             endDate = LocalDate.now();
+        }
+        else if (startDate == null) {
+            startDate = endDate.minusDays(MAX_HOUR_PERIOD -1);
+        }
+        else if (endDate == null) {
+            endDate = startDate.plusDays(MAX_HOUR_PERIOD -1);
+        }
+
+        if (endDate.isAfter(LocalDate.now())) {
+            endDate = LocalDate.now();
+        }
+
+        if (startDate.isAfter(endDate) || exceedMaxPeriod(startDate, endDate, timeType)) {
+            throw new CustomException(ErrorCode.INVALID_STATISTICS_DATE);
         }
 
         List<StatisticsResDto> responses =
                 statisticsService.getCountsForEachTimeByHashtag(hashtag, timeType, startDate, endDate, valueType, sortType);
 
         return ResponseEntity.ok(responses);
+    }
+
+    private boolean exceedMaxPeriod(LocalDate startDate, LocalDate endDate, StatisticsTimeType timeType) {
+        return (timeType == StatisticsTimeType.DATE && startDate.until(endDate, ChronoUnit.DAYS) > MAX_DATE_PERIOD - 1)
+                || (timeType == StatisticsTimeType.HOUR && startDate.until(endDate, ChronoUnit.DAYS) > MAX_HOUR_PERIOD - 1);
     }
 
 }

--- a/src/main/java/com/wanted/teamV/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamV/controller/StatisticsController.java
@@ -1,9 +1,8 @@
 package com.wanted.teamV.controller;
 
 import com.wanted.teamV.dto.res.StatisticsResDto;
-import com.wanted.teamV.exception.CustomException;
-import com.wanted.teamV.exception.ErrorCode;
 import com.wanted.teamV.service.StatisticsService;
+import com.wanted.teamV.type.StatisticsSortType;
 import com.wanted.teamV.type.StatisticsTimeType;
 import com.wanted.teamV.type.StatisticsValueType;
 import lombok.RequiredArgsConstructor;
@@ -21,26 +20,28 @@ public class StatisticsController {
 
     @GetMapping
     public ResponseEntity<List<StatisticsResDto>> getStatistics(
-        @RequestParam(required = false) String hashtag,
-        @RequestParam StatisticsTimeType type,
-        @RequestParam(required = false) LocalDate start,
-        @RequestParam(required = false) LocalDate end,
-        @RequestParam(required = false, defaultValue = "count") StatisticsValueType value
+        @RequestParam(value = "hashtag", required = false) String hashtag,
+        @RequestParam(value = "start", required = false) LocalDate startDate,
+        @RequestParam(value = "end", required = false) LocalDate endDate,
+        @RequestParam(value = "type", required = false, defaultValue = "date") StatisticsTimeType timeType,
+        @RequestParam(value = "value", required = false, defaultValue = "count") StatisticsValueType valueType,
+        @RequestParam(value = "sort", required = false, defaultValue = "desc") StatisticsSortType sortType
+
     ) {
 
         if (hashtag == null || hashtag.isBlank()) {
             // TODO - JWT 토큰에서 본인 계정 불러오기
             hashtag = "맛집";
         }
-        if (start == null) {
-            start = LocalDate.now().minusDays(7);
+        if (startDate == null) {
+            startDate = LocalDate.now().minusDays(7);
         }
-        if (end == null) {
-            end = LocalDate.now();
+        if (endDate == null) {
+            endDate = LocalDate.now();
         }
 
         List<StatisticsResDto> responses =
-                statisticsService.getCountsForEachTimeByHashtag(hashtag, type, start, end, value);
+                statisticsService.getCountsForEachTimeByHashtag(hashtag, timeType, startDate, endDate, valueType, sortType);
 
         return ResponseEntity.ok(responses);
     }

--- a/src/main/java/com/wanted/teamV/controller/StatisticsController.java
+++ b/src/main/java/com/wanted/teamV/controller/StatisticsController.java
@@ -1,18 +1,21 @@
 package com.wanted.teamV.controller;
 
+import com.wanted.teamV.dto.LoginMember;
 import com.wanted.teamV.dto.res.StatisticsResDto;
 import com.wanted.teamV.entity.Member;
 import com.wanted.teamV.exception.CustomException;
 import com.wanted.teamV.exception.ErrorCode;
 import com.wanted.teamV.repository.MemberRepository;
-import com.wanted.teamV.service.MemberService;
 import com.wanted.teamV.service.StatisticsService;
 import com.wanted.teamV.type.StatisticsSortType;
 import com.wanted.teamV.type.StatisticsTimeType;
 import com.wanted.teamV.type.StatisticsValueType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -27,23 +30,21 @@ public class StatisticsController {
     private static final int MAX_HOUR_PERIOD = 7;
 
     private final StatisticsService statisticsService;
-    private final MemberService memberService;
     private final MemberRepository memberRepository;
 
     @GetMapping
     public ResponseEntity<List<StatisticsResDto>> getStatistics(
-        @RequestHeader(value = "Authorization", required = false) String authToken,
+        @AuthenticationPrincipal LoginMember loginMember,
         @RequestParam(value = "hashtag", required = false) String hashtag,
         @RequestParam(value = "start", required = false) LocalDate startDate,
         @RequestParam(value = "end", required = false) LocalDate endDate,
         @RequestParam(value = "type", required = false, defaultValue = "date") StatisticsTimeType timeType,
         @RequestParam(value = "value", required = false, defaultValue = "count") StatisticsValueType valueType,
         @RequestParam(value = "sort", required = false, defaultValue = "desc") StatisticsSortType sortType
-
     ) {
 
         if (hashtag == null || hashtag.isBlank()) {
-            hashtag = getMemberAccount(authToken);
+            hashtag = getMemberAccount(loginMember.id());
         }
 
         if (startDate == null && endDate == null) {
@@ -71,11 +72,7 @@ public class StatisticsController {
         return ResponseEntity.ok(responses);
     }
 
-    private String getMemberAccount(String authToken) {
-        if (authToken == null || authToken.isBlank()) {
-            throw new CustomException(ErrorCode.INVALID_REQUEST);
-        }
-        Long memberId = memberService.extractUserId(authToken);
+    private String getMemberAccount(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST));
         return member.getAccount();

--- a/src/main/java/com/wanted/teamV/dto/res/StatisticsResDto.java
+++ b/src/main/java/com/wanted/teamV/dto/res/StatisticsResDto.java
@@ -1,0 +1,19 @@
+package com.wanted.teamV.dto.res;
+
+import com.wanted.teamV.type.StatisticsTimeType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class StatisticsResDto {
+    private String time;
+    private long value;
+
+    public StatisticsResDto(StatisticsTimeType timeType, LocalDateTime time, long value) {
+        this.time = time.format(timeType.getFormatter());
+        this.value = value;
+    }
+}

--- a/src/main/java/com/wanted/teamV/entity/PostHistory.java
+++ b/src/main/java/com/wanted/teamV/entity/PostHistory.java
@@ -8,12 +8,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class PostHistory {
     @Id
     @Column(name = "history_id")

--- a/src/main/java/com/wanted/teamV/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamV/exception/ErrorCode.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     NOT_FOUND(HttpStatus.BAD_REQUEST, "요청사항을 찾지 못했습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_STATISTICS_DATE(HttpStatus.BAD_REQUEST, "잘못된 조회 기간입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다."),
     ;
 

--- a/src/main/java/com/wanted/teamV/repository/PostHashtagRepository.java
+++ b/src/main/java/com/wanted/teamV/repository/PostHashtagRepository.java
@@ -1,12 +1,13 @@
 package com.wanted.teamV.repository;
 
 import com.wanted.teamV.entity.PostHashtag;
-import com.wanted.teamV.entity.PostHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
-
+    List<PostHashtag> findAllByHashtag(String hashtag);
 }
 

--- a/src/main/java/com/wanted/teamV/repository/PostHistoryRepository.java
+++ b/src/main/java/com/wanted/teamV/repository/PostHistoryRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostHistoryRepository extends JpaRepository<PostHistory, Long> {
+public interface PostHistoryRepository extends JpaRepository<PostHistory, Long>, PostHistoryRepositoryCustom {
 
 }
 

--- a/src/main/java/com/wanted/teamV/repository/PostHistoryRepositoryCustom.java
+++ b/src/main/java/com/wanted/teamV/repository/PostHistoryRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.wanted.teamV.repository;
+
+import com.wanted.teamV.type.HistoryType;
+import com.wanted.teamV.type.StatisticsTimeType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public interface PostHistoryRepositoryCustom {
+    Map<String, Long> countsByTypeInPostIdsGroupByTimeType(HistoryType type, List<Long> postIds,
+                                                           LocalDateTime startDateTime, LocalDateTime endDateTime, StatisticsTimeType timeType);
+}

--- a/src/main/java/com/wanted/teamV/repository/PostRepository.java
+++ b/src/main/java/com/wanted/teamV/repository/PostRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
 }
 

--- a/src/main/java/com/wanted/teamV/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/wanted/teamV/repository/PostRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.wanted.teamV.repository;
+
+import com.wanted.teamV.type.StatisticsTimeType;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public interface PostRepositoryCustom {
+    Map<String, Long> countsByHashtagGroupByTimeType(String hashtag, LocalDateTime startDateTime, LocalDateTime endDateTime, StatisticsTimeType timeType);
+}

--- a/src/main/java/com/wanted/teamV/repository/impl/PostHistoryRepositoryImpl.java
+++ b/src/main/java/com/wanted/teamV/repository/impl/PostHistoryRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.wanted.teamV.repository.impl;
+
+import com.querydsl.core.types.Constant;
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.teamV.repository.PostHistoryRepositoryCustom;
+import com.wanted.teamV.type.HistoryType;
+import com.wanted.teamV.type.StatisticsTimeType;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.wanted.teamV.entity.QPostHistory.postHistory;
+import static com.wanted.teamV.type.StatisticsTimeType.DATE;
+
+@RequiredArgsConstructor
+public class PostHistoryRepositoryImpl implements PostHistoryRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    // 기록 타입, 게시물 아이디 목록, 기간으로 기록을 조회하여 날짜/시간별 카운트를 구함
+    @Override
+    public Map<String, Long> countsByTypeInPostIdsGroupByTimeType(HistoryType type, List<Long> postIds,
+                                                                  LocalDateTime startDateTime, LocalDateTime endDateTime, StatisticsTimeType timeType) {
+        StringTemplate formattedDate = getFormattedDate(timeType);
+        return queryFactory
+                .select(formattedDate, postHistory.count())
+                .from(postHistory)
+                .where(
+                        postHistory.post.id.in(postIds),
+                        postHistory.type.eq(type),
+                        postHistory.createdAt.between(startDateTime, endDateTime)
+                )
+                .groupBy(formattedDate)
+                .fetch()
+                .stream().collect(
+                        Collectors.toMap(
+                                tuple -> tuple.get(formattedDate),
+                                tuple -> tuple.get(postHistory.count())
+                        )
+                );
+    }
+
+    // 시간 형식에 맞춰 MySQL 쿼리에 사용할 템플릿 객체 생성 (group by시 사용됨)
+    private static StringTemplate getFormattedDate(StatisticsTimeType timeType) {
+        Constant<String> formatConstant = timeType == DATE ? ConstantImpl.create("%Y-%m-%d") : ConstantImpl.create("%Y-%m-%d-%h");
+
+        return Expressions.stringTemplate(
+                "DATE_FORMAT({0},{1})",
+                postHistory.createdAt,
+                formatConstant);
+    }
+}

--- a/src/main/java/com/wanted/teamV/repository/impl/PostRepositoryImpl.java
+++ b/src/main/java/com/wanted/teamV/repository/impl/PostRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.wanted.teamV.repository.impl;
+
+import com.querydsl.core.types.Constant;
+import com.querydsl.core.types.ConstantImpl;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wanted.teamV.repository.PostRepositoryCustom;
+import com.wanted.teamV.type.StatisticsTimeType;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.wanted.teamV.entity.QPost.post;
+import static com.wanted.teamV.entity.QPostHashtag.postHashtag;
+import static com.wanted.teamV.type.StatisticsTimeType.DATE;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    // 해시태그, 작성된 날짜로 게시물을 조회하여 날짜/시간별 카운트를 구함
+    @Override
+    public Map<String, Long> countsByHashtagGroupByTimeType(String hashtag, LocalDateTime startDateTime, LocalDateTime endDateTime, StatisticsTimeType timeType) {
+        StringTemplate formattedDate = getFormattedDate(timeType);
+        return queryFactory
+                .select(formattedDate, postHashtag.post.count())
+                .from(postHashtag)
+                .where(
+                        postHashtag.hashtag.eq(hashtag),
+                        postHashtag.post.createdAt.between(startDateTime, endDateTime)
+                )
+                .groupBy(formattedDate)
+                .fetch()
+                .stream().collect(
+                        Collectors.toMap(
+                                tuple -> tuple.get(formattedDate),
+                                tuple -> tuple.get(postHashtag.post.count())
+                        )
+                );
+    }
+
+    private static StringTemplate getFormattedDate(StatisticsTimeType timeType) {
+        Constant<String> formatConstant = timeType == DATE ? ConstantImpl.create("%Y-%m-%d") : ConstantImpl.create("%Y-%m-%d-%h");
+
+        return Expressions.stringTemplate(
+                "DATE_FORMAT({0},{1})",
+                post.createdAt,
+                formatConstant);
+    }
+}

--- a/src/main/java/com/wanted/teamV/service/StatisticsService.java
+++ b/src/main/java/com/wanted/teamV/service/StatisticsService.java
@@ -1,6 +1,7 @@
 package com.wanted.teamV.service;
 
 import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.type.StatisticsSortType;
 import com.wanted.teamV.type.StatisticsTimeType;
 import com.wanted.teamV.type.StatisticsValueType;
 
@@ -8,5 +9,5 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface StatisticsService {
-    List<StatisticsResDto> getCountsForEachTimeByHashtag(String hashtag, StatisticsTimeType timeType, LocalDate startDate, LocalDate endDate, StatisticsValueType valueType);
+    List<StatisticsResDto> getCountsForEachTimeByHashtag(String hashtag, StatisticsTimeType timeType, LocalDate startDate, LocalDate endDate, StatisticsValueType valueType, StatisticsSortType sortType);
 }

--- a/src/main/java/com/wanted/teamV/service/StatisticsService.java
+++ b/src/main/java/com/wanted/teamV/service/StatisticsService.java
@@ -1,0 +1,12 @@
+package com.wanted.teamV.service;
+
+import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.type.StatisticsTimeType;
+import com.wanted.teamV.type.StatisticsValueType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface StatisticsService {
+    List<StatisticsResDto> getCountsForEachTimeByHashtag(String hashtag, StatisticsTimeType timeType, LocalDate startDate, LocalDate endDate, StatisticsValueType valueType);
+}

--- a/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
@@ -2,6 +2,7 @@ package com.wanted.teamV.service.impl;
 
 import com.wanted.teamV.dto.res.StatisticsResDto;
 import com.wanted.teamV.service.StatisticsService;
+import com.wanted.teamV.type.StatisticsSortType;
 import com.wanted.teamV.type.StatisticsTimeType;
 import com.wanted.teamV.type.StatisticsValueType;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class StatisticsServiceImpl implements StatisticsService {
     @Override
-    public List<StatisticsResDto> getCountsForEachTimeByHashtag(String hashtag, StatisticsTimeType timeType, LocalDate startDate, LocalDate endDate, StatisticsValueType valueType) {
+    public List<StatisticsResDto> getCountsForEachTimeByHashtag(String hashtag, StatisticsTimeType timeType, LocalDate startDate, LocalDate endDate, StatisticsValueType valueType, StatisticsSortType sortType) {
         return List.of(
                 new StatisticsResDto(timeType, LocalDateTime.of(startDate, LocalTime.MIN), 10),
                 new StatisticsResDto(timeType, LocalDateTime.of(startDate.minusDays(1), LocalTime.MIN.plusHours(1)), 11),

--- a/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
@@ -71,13 +71,14 @@ public class StatisticsServiceImpl implements StatisticsService {
         }
 
         dateStream.forEach(date -> {
+            String dateString = date.format(DateTimeFormatter.ISO_LOCAL_DATE);
             if (timeType == StatisticsTimeType.HOUR) {
                 for (int i = 0; i < 24; i++) {
                     LocalDateTime dateTime = date.atTime(i, 0);
-                    dateTimes.put(dateTime, dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd-hh")));
+                    dateTimes.put(dateTime, String.format("%s-%02d", dateString, i));
                 }
             } else {
-                dateTimes.put(date.atStartOfDay(), date.format(DateTimeFormatter.ISO_LOCAL_DATE));
+                dateTimes.put(date.atStartOfDay(), dateString);
             }
         });
         return dateTimes;

--- a/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
@@ -1,0 +1,29 @@
+package com.wanted.teamV.service.impl;
+
+import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.service.StatisticsService;
+import com.wanted.teamV.type.StatisticsTimeType;
+import com.wanted.teamV.type.StatisticsValueType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticsServiceImpl implements StatisticsService {
+    @Override
+    public List<StatisticsResDto> getCountsForEachTimeByHashtag(String hashtag, StatisticsTimeType timeType, LocalDate startDate, LocalDate endDate, StatisticsValueType valueType) {
+        return List.of(
+                new StatisticsResDto(timeType, LocalDateTime.of(startDate, LocalTime.MIN), 10),
+                new StatisticsResDto(timeType, LocalDateTime.of(startDate.minusDays(1), LocalTime.MIN.plusHours(1)), 11),
+                new StatisticsResDto(timeType, LocalDateTime.of(startDate.minusDays(2), LocalTime.MIN.plusHours(2)), 12),
+                new StatisticsResDto(timeType, LocalDateTime.of(startDate.minusDays(3), LocalTime.MIN.plusHours(3)), 13)
+        );
+    }
+}

--- a/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
+++ b/src/main/java/com/wanted/teamV/service/impl/StatisticsServiceImpl.java
@@ -1,7 +1,11 @@
 package com.wanted.teamV.service.impl;
 
 import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.repository.PostHashtagRepository;
+import com.wanted.teamV.repository.PostHistoryRepository;
+import com.wanted.teamV.repository.PostRepository;
 import com.wanted.teamV.service.StatisticsService;
+import com.wanted.teamV.type.HistoryType;
 import com.wanted.teamV.type.StatisticsSortType;
 import com.wanted.teamV.type.StatisticsTimeType;
 import com.wanted.teamV.type.StatisticsValueType;
@@ -12,19 +16,70 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StatisticsServiceImpl implements StatisticsService {
+
+    private final PostRepository postRepository;
+    private final PostHistoryRepository historyRepository;
+    private final PostHashtagRepository postHashtagRepository;
+
     @Override
     public List<StatisticsResDto> getCountsForEachTimeByHashtag(String hashtag, StatisticsTimeType timeType, LocalDate startDate, LocalDate endDate, StatisticsValueType valueType, StatisticsSortType sortType) {
-        return List.of(
-                new StatisticsResDto(timeType, LocalDateTime.of(startDate, LocalTime.MIN), 10),
-                new StatisticsResDto(timeType, LocalDateTime.of(startDate.minusDays(1), LocalTime.MIN.plusHours(1)), 11),
-                new StatisticsResDto(timeType, LocalDateTime.of(startDate.minusDays(2), LocalTime.MIN.plusHours(2)), 12),
-                new StatisticsResDto(timeType, LocalDateTime.of(startDate.minusDays(3), LocalTime.MIN.plusHours(3)), 13)
-        );
+        Map<String, Long> historyCounts;
+        if (valueType == StatisticsValueType.COUNT) {
+            historyCounts = postRepository.countsByHashtagGroupByTimeType(
+                    hashtag,
+                    startDate.atStartOfDay(),
+                    endDate.atTime(LocalTime.MAX),
+                    timeType);
+        } else {
+            List<Long> postIds = postHashtagRepository.findAllByHashtag(hashtag)
+                    .stream().map(it -> it.getPost().getId()).toList();
+
+            historyCounts = historyRepository.countsByTypeInPostIdsGroupByTimeType(
+                    HistoryType.parseStatisticsValueType(valueType),
+                    postIds,
+                    startDate.atStartOfDay(),
+                    endDate.atTime(LocalTime.MAX),
+                    timeType);
+        }
+
+        Map<LocalDateTime, String> dateTimesAndKeys = getDateTimesAndKeysWithOrder(timeType, startDate, endDate, sortType);
+
+        List<StatisticsResDto> results = new ArrayList<>();
+        dateTimesAndKeys.forEach((dateTime, key) -> {
+            long count = historyCounts.containsKey(key) ? historyCounts.get(key) : 0;
+            results.add(new StatisticsResDto(timeType, dateTime, count));
+        });
+        return results;
+    }
+
+    // 시작날짜부터 종료날짜까지를 날짜 또는 시간마다 쪼개서 정렬하고, DB조회 결과와 매칭할 형식과 함께 Map으로 반환하는 함수
+    private static Map<LocalDateTime, String> getDateTimesAndKeysWithOrder(StatisticsTimeType timeType,
+                                                                           LocalDate startDate, LocalDate endDate, StatisticsSortType sortType) {
+        Map<LocalDateTime, String> dateTimes = new LinkedHashMap<>();
+
+        Stream<LocalDate> dateStream = startDate.datesUntil(endDate.plusDays(1));
+        if (sortType == StatisticsSortType.DESC) {
+            dateStream = dateStream.sorted(Comparator.reverseOrder());
+        }
+
+        dateStream.forEach(date -> {
+            if (timeType == StatisticsTimeType.HOUR) {
+                for (int i = 0; i < 24; i++) {
+                    LocalDateTime dateTime = date.atTime(i, 0);
+                    dateTimes.put(dateTime, dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd-hh")));
+                }
+            } else {
+                dateTimes.put(date.atStartOfDay(), date.format(DateTimeFormatter.ISO_LOCAL_DATE));
+            }
+        });
+        return dateTimes;
     }
 }

--- a/src/main/java/com/wanted/teamV/type/HistoryType.java
+++ b/src/main/java/com/wanted/teamV/type/HistoryType.java
@@ -4,4 +4,13 @@ public enum HistoryType {
     VIEW,
     LIKE,
     SHARE
+    ;
+
+    public static HistoryType parseStatisticsValueType(StatisticsValueType valueType) {
+        return switch (valueType) {
+            case VIEW_COUNT, COUNT -> VIEW;
+            case LIKE_COUNT -> LIKE;
+            case SHARE_COUNT -> SHARE;
+        };
+    }
 }

--- a/src/main/java/com/wanted/teamV/type/StatisticsSortType.java
+++ b/src/main/java/com/wanted/teamV/type/StatisticsSortType.java
@@ -1,0 +1,15 @@
+package com.wanted.teamV.type;
+
+public enum StatisticsSortType {
+    ASC,
+    DESC;
+
+    public static StatisticsSortType parse(String value) {
+        for (StatisticsSortType type : StatisticsSortType.values()) {
+            if (type.name().equals(value)) {
+                return type;
+            }
+        }
+        return DESC;
+    }
+}

--- a/src/main/java/com/wanted/teamV/type/StatisticsTimeType.java
+++ b/src/main/java/com/wanted/teamV/type/StatisticsTimeType.java
@@ -1,0 +1,29 @@
+package com.wanted.teamV.type;
+
+import java.time.format.DateTimeFormatter;
+
+public enum StatisticsTimeType {
+    DATE(DateTimeFormatter.ISO_LOCAL_DATE),
+    HOUR(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    ;
+
+    private final DateTimeFormatter formatter;
+
+    StatisticsTimeType(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    public DateTimeFormatter getFormatter() {
+        return formatter;
+    }
+
+    public static StatisticsTimeType parse(String value) {
+        for (StatisticsTimeType type : StatisticsTimeType.values()) {
+            if (type.name().equals(value)) {
+                return type;
+            }
+        }
+        return DATE;
+    }
+
+}

--- a/src/main/java/com/wanted/teamV/type/StatisticsValueType.java
+++ b/src/main/java/com/wanted/teamV/type/StatisticsValueType.java
@@ -1,0 +1,19 @@
+package com.wanted.teamV.type;
+
+public enum StatisticsValueType {
+    COUNT,
+    VIEW_COUNT,
+    LIKE_COUNT,
+    SHARE_COUNT
+    ;
+
+    public static StatisticsValueType parse(String value) {
+        for (StatisticsValueType type : StatisticsValueType.values()) {
+            if (type.name().equals(value)) {
+                return type;
+            }
+        }
+        return COUNT;
+    }
+
+}

--- a/src/main/java/com/wanted/teamV/type/converter/StringToStatisticsSortTypeConverter.java
+++ b/src/main/java/com/wanted/teamV/type/converter/StringToStatisticsSortTypeConverter.java
@@ -1,0 +1,11 @@
+package com.wanted.teamV.type.converter;
+
+import com.wanted.teamV.type.StatisticsSortType;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToStatisticsSortTypeConverter implements Converter<String, StatisticsSortType> {
+    @Override
+    public StatisticsSortType convert(String value) {
+        return StatisticsSortType.parse(value.toUpperCase());
+    }
+}

--- a/src/main/java/com/wanted/teamV/type/converter/StringToStatisticsTimeTypeConverter.java
+++ b/src/main/java/com/wanted/teamV/type/converter/StringToStatisticsTimeTypeConverter.java
@@ -1,0 +1,11 @@
+package com.wanted.teamV.type.converter;
+
+import com.wanted.teamV.type.StatisticsTimeType;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToStatisticsTimeTypeConverter implements Converter<String, StatisticsTimeType> {
+    @Override
+    public StatisticsTimeType convert(String value) {
+        return StatisticsTimeType.parse(value.toUpperCase());
+    }
+}

--- a/src/main/java/com/wanted/teamV/type/converter/StringToStatisticsValueTypeConverter.java
+++ b/src/main/java/com/wanted/teamV/type/converter/StringToStatisticsValueTypeConverter.java
@@ -1,0 +1,11 @@
+package com.wanted.teamV.type.converter;
+
+import com.wanted.teamV.type.StatisticsValueType;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToStatisticsValueTypeConverter implements Converter<String, StatisticsValueType> {
+    @Override
+    public StatisticsValueType convert(String value) {
+        return StatisticsValueType.parse(value.toUpperCase());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,9 +10,8 @@ spring:
       ddl-auto: validate
       show-sql: true
       properties:
-        hibernate:
-          format_sql: true
-          dialect: org.hibernate.dialect.MySQLDialect
+        hibernate.format_sql: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,6 @@ spring:
       properties:
         hibernate.format_sql: true
 
-
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/sns_teamv?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password:
+    password: 1234
 
   jpa:
     hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,8 @@ spring:
       show-sql: true
       properties:
         hibernate.format_sql: true
-    database-platform: org.hibernate.dialect.MySQL8Dialect
+        dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/sns_teamv?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: root
-    password: 1234
+    password:
 
   jpa:
     hibernate:
@@ -11,7 +11,6 @@ spring:
       show-sql: true
       properties:
         hibernate.format_sql: true
-        dialect: org.hibernate.dialect.MySQL8InnoDBDialect
 
 
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,9 @@ spring:
       ddl-auto: validate
       show-sql: true
       properties:
-        hibernate.format_sql: true
+        hibernate:
+          format_sql: true
+          dialect: org.hibernate.dialect.MySQLDialect
 
 logging:
   level:

--- a/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
@@ -1,0 +1,35 @@
+package com.wanted.teamV.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMapAdapter;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+@SpringBootTest
+@Transactional
+class StatisticsControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void getStatisticsWithDate() throws Exception {
+        MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
+        params.add("hashtag", "맛집");
+        params.add("type", "hour");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                .params(params))
+                .andExpect(status().isOk())
+                .andDo(print());
+
+    }
+}

--- a/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
@@ -1,16 +1,27 @@
 package com.wanted.teamV.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import com.wanted.teamV.dto.req.MemberApproveReqDto;
+import com.wanted.teamV.dto.req.MemberJoinReqDto;
+import com.wanted.teamV.dto.req.MemberLoginReqDto;
+import com.wanted.teamV.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMapAdapter;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @AutoConfigureMockMvc
@@ -19,17 +30,135 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class StatisticsControllerTest {
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
-    public void getStatisticsWithDate() throws Exception {
+    @DisplayName("통계 조회 API의 응답 형식이 잘 맞는지 확인한다. (일자/시간 및 정렬")
+    public void response_format_test() throws Exception {
         MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
         params.add("hashtag", "맛집");
+
+        // 일자, 내림차순
+        params.add("start", "2023-10-10");
+        params.add("end", "2023-10-13");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(4))
+                .andExpect(jsonPath("$[0].time").value("2023-10-13"))
+                .andDo(print());
+
+        // 일자, 오름차순
+        params.add("sort", "asc");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(4))
+                .andExpect(jsonPath("$[0].time").value("2023-10-10"))
+                .andDo(print());
+
+        // 시간, 오름차순
         params.add("type", "hour");
 
         mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
-                .params(params))
+                        .params(params))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(4 * 24))
+                .andExpect(jsonPath("$[0].time").value("2023-10-10T00:00:00"))
                 .andDo(print());
 
+        // 시간, 내림차순
+        params.remove("sort");
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(4 * 24))
+                .andExpect(jsonPath("$[0].time").value("2023-10-13T00:00:00"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("조회 가능 기간을 초과하여 조회에 실패한다.")
+    public void exceed_max_period() throws Exception {
+        // type=date인 경우 최대 31일
+        MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
+        params.add("hashtag", "맛집");
+        params.add("start", "2022-10-01");
+        params.add("end", "2022-11-01");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                .params(params))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_STATISTICS_DATE.name()))
+                .andDo(print());
+
+        // type=hour인 경우 최대 7일
+        params.add("type", "hour");
+        params.set("end", "2022-10-08");
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_STATISTICS_DATE.name()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("hashtag 값이 없는 경우 토큰에서 사용자 정보를 구하여 계정을 대신 사용한다.")
+    public void no_hashtag_but_has_token() throws Exception {
+        // 회원가입
+        MemberJoinReqDto joinReqDto = new MemberJoinReqDto("qwertyasdf12345", "abc@gmail.com", "qwerty1234!");
+        MvcResult result = mockMvc.perform(post("/members")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(joinReqDto))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        String response = result.getResponse().getContentAsString();
+        String code = JsonPath.parse(response).read("$.code");
+
+        // 가입승인
+        MemberApproveReqDto approveReqDto = new MemberApproveReqDto("qwertyasdf12345", "qwerty1234!", code);
+        mockMvc.perform(post("/members/approve")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(approveReqDto))
+                )
+                .andExpect(status().isNoContent());
+
+        // 로그인
+        MemberLoginReqDto loginReqDto = new MemberLoginReqDto("qwertyasdf12345", "qwerty1234!");
+        result = mockMvc.perform(post("/members/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginReqDto))
+                )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        response = result.getResponse().getContentAsString();
+        String token = JsonPath.parse(response).read("$.accessToken");
+
+
+        // 통계 조회
+        MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
+        params.add("start", "2022-10-01");
+        params.add("end", "2022-10-10");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                .params(params)
+                .header("Authorization", token))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("hashtag 값이 없는데 토큰도 없으면 요청에 실패한다.")
+    public void no_hashtag_and_token() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_REQUEST.name()))
+                .andDo(print());
     }
 }

--- a/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
@@ -6,6 +6,7 @@ import com.wanted.teamV.dto.req.MemberApproveReqDto;
 import com.wanted.teamV.dto.req.MemberJoinReqDto;
 import com.wanted.teamV.dto.req.MemberLoginReqDto;
 import com.wanted.teamV.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,81 +34,10 @@ class StatisticsControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Test
-    @DisplayName("통계 조회 API의 응답 형식이 잘 맞는지 확인한다. (일자/시간 및 정렬")
-    public void response_format_test() throws Exception {
-        MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
-        params.add("hashtag", "맛집");
+    private String accessToken;
 
-        // 일자, 내림차순
-        params.add("start", "2023-10-10");
-        params.add("end", "2023-10-13");
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
-                        .params(params))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(4))
-                .andExpect(jsonPath("$[0].time").value("2023-10-13"))
-                .andDo(print());
-
-        // 일자, 오름차순
-        params.add("sort", "asc");
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
-                        .params(params))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(4))
-                .andExpect(jsonPath("$[0].time").value("2023-10-10"))
-                .andDo(print());
-
-        // 시간, 오름차순
-        params.add("type", "hour");
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
-                        .params(params))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(4 * 24))
-                .andExpect(jsonPath("$[0].time").value("2023-10-10T00:00:00"))
-                .andDo(print());
-
-        // 시간, 내림차순
-        params.remove("sort");
-        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
-                        .params(params))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(4 * 24))
-                .andExpect(jsonPath("$[0].time").value("2023-10-13T00:00:00"))
-                .andDo(print());
-    }
-
-    @Test
-    @DisplayName("조회 가능 기간을 초과하여 조회에 실패한다.")
-    public void exceed_max_period() throws Exception {
-        // type=date인 경우 최대 31일
-        MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
-        params.add("hashtag", "맛집");
-        params.add("start", "2022-10-01");
-        params.add("end", "2022-11-01");
-
-        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
-                .params(params))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_STATISTICS_DATE.name()))
-                .andDo(print());
-
-        // type=hour인 경우 최대 7일
-        params.add("type", "hour");
-        params.set("end", "2022-10-08");
-        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
-                        .params(params))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_STATISTICS_DATE.name()))
-                .andDo(print());
-    }
-
-    @Test
-    @DisplayName("hashtag 값이 없는 경우 토큰에서 사용자 정보를 구하여 계정을 대신 사용한다.")
-    public void no_hashtag_but_has_token() throws Exception {
+    @BeforeEach
+    void setUp() throws Exception {
         // 회원가입
         MemberJoinReqDto joinReqDto = new MemberJoinReqDto("qwertyasdf12345", "abc@gmail.com", "qwerty1234!");
         MvcResult result = mockMvc.perform(post("/members")
@@ -138,27 +68,99 @@ class StatisticsControllerTest {
                 .andReturn();
 
         response = result.getResponse().getContentAsString();
-        String token = JsonPath.parse(response).read("$.accessToken");
+        accessToken = JsonPath.parse(response).read("$.accessToken");
+    }
 
+    @Test
+    @DisplayName("통계 조회 API의 응답 형식이 잘 맞는지 확인한다. (일자/시간 및 정렬")
+    public void response_format_test() throws Exception {
+        MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
+        params.add("hashtag", "맛집");
 
+        // 일자, 내림차순
+        params.add("start", "2023-10-10");
+        params.add("end", "2023-10-13");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(4))
+                .andExpect(jsonPath("$[0].time").value("2023-10-13"))
+                .andDo(print());
+
+        // 일자, 오름차순
+        params.add("sort", "asc");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(4))
+                .andExpect(jsonPath("$[0].time").value("2023-10-10"))
+                .andDo(print());
+
+        // 시간, 오름차순
+        params.add("type", "hour");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(4 * 24))
+                .andExpect(jsonPath("$[0].time").value("2023-10-10T00:00:00"))
+                .andDo(print());
+
+        // 시간, 내림차순
+        params.remove("sort");
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(4 * 24))
+                .andExpect(jsonPath("$[0].time").value("2023-10-13T00:00:00"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("조회 가능 기간을 초과하여 조회에 실패한다.")
+    public void exceed_max_period() throws Exception {
+        // type=date인 경우 최대 31일
+        MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
+        params.add("hashtag", "맛집");
+        params.add("start", "2022-10-01");
+        params.add("end", "2022-11-01");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_STATISTICS_DATE.name()))
+                .andDo(print());
+
+        // type=hour인 경우 최대 7일
+        params.add("type", "hour");
+        params.set("end", "2022-10-08");
+        mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
+                        .params(params)
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_STATISTICS_DATE.name()))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("hashtag 값이 없는 경우 토큰에서 사용자 정보를 구하여 계정을 대신 사용한다.")
+    public void no_hashtag_but_has_token() throws Exception {
         // 통계 조회
         MultiValueMapAdapter<String, String> params = new LinkedMultiValueMap<>();
         params.add("start", "2022-10-01");
         params.add("end", "2022-10-10");
 
         mockMvc.perform(MockMvcRequestBuilders.get("/statistics")
-                .params(params)
-                .header("Authorization", token))
+                        .params(params)
+                        .header("Authorization", "Bearer " + accessToken))
                 .andExpect(status().isOk())
-                .andDo(print());
-    }
-
-    @Test
-    @DisplayName("hashtag 값이 없는데 토큰도 없으면 요청에 실패한다.")
-    public void no_hashtag_and_token() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/statistics"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.errorCode").value(ErrorCode.INVALID_REQUEST.name()))
                 .andDo(print());
     }
 }

--- a/src/test/java/com/wanted/teamV/service/impl/StatisticsServiceImplTest.java
+++ b/src/test/java/com/wanted/teamV/service/impl/StatisticsServiceImplTest.java
@@ -1,0 +1,160 @@
+package com.wanted.teamV.service.impl;
+
+import com.wanted.teamV.dto.res.StatisticsResDto;
+import com.wanted.teamV.entity.Post;
+import com.wanted.teamV.entity.PostHashtag;
+import com.wanted.teamV.repository.PostHashtagRepository;
+import com.wanted.teamV.repository.PostHistoryRepository;
+import com.wanted.teamV.repository.PostRepository;
+import com.wanted.teamV.type.StatisticsSortType;
+import com.wanted.teamV.type.StatisticsTimeType;
+import com.wanted.teamV.type.StatisticsValueType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticsServiceImplTest {
+
+    @Mock
+    private PostRepository postRepository;
+    @Mock
+    private PostHashtagRepository hashtagRepository;
+    @Mock
+    private PostHistoryRepository historyRepository;
+    @InjectMocks
+    private StatisticsServiceImpl statisticsService;
+
+    @Test
+    @DisplayName("날짜별 통계 정보(조회수/좋아요/공유)를 불러온다.")
+    public void get_statistics_with_date() {
+        // given
+        String hashtag = "맛집";
+        StatisticsTimeType timeType = StatisticsTimeType.DATE;
+        LocalDate startDate = LocalDate.of(2023, 10, 20);
+        LocalDate endDate = LocalDate.of(2023, 10, 23);
+        StatisticsValueType valueType = StatisticsValueType.LIKE_COUNT;
+        StatisticsSortType sortType = StatisticsSortType.DESC;
+
+        PostHashtag postHashtag = mock(PostHashtag.class);
+        Post post = mock(Post.class);
+        when(postHashtag.getPost()).thenReturn(post);
+        when(post.getId()).thenReturn(1L);
+        when(hashtagRepository.findAllByHashtag(hashtag))
+                .thenReturn(List.of(postHashtag));
+
+        when(historyRepository.countsByTypeInPostIdsGroupByTimeType(any(), anyList(), any(), any(), eq(timeType)))
+                .thenReturn(Map.of("2023-10-20", 1L, "2023-10-22", 2L));
+
+        // when
+        List<StatisticsResDto> responses = statisticsService.getCountsForEachTimeByHashtag(
+                hashtag, timeType, startDate, endDate, valueType, sortType);
+
+        // then
+        Assertions.assertEquals("2023-10-23", responses.get(0).getTime());
+        Assertions.assertEquals("2023-10-22", responses.get(1).getTime());
+        Assertions.assertEquals("2023-10-21", responses.get(2).getTime());
+        Assertions.assertEquals("2023-10-20", responses.get(3).getTime());
+        Assertions.assertEquals(0, responses.get(0).getValue());
+        Assertions.assertEquals(2L, responses.get(1).getValue());
+        Assertions.assertEquals(0, responses.get(2).getValue());
+        Assertions.assertEquals(1L, responses.get(3).getValue());
+    }
+
+    @Test
+    @DisplayName("날짜+시간별 통계 정보(조회수/좋아요/공유)를 불러온다.")
+    public void get_statistics_with_hour() {
+        // given
+        String hashtag = "맛집";
+        StatisticsTimeType timeType = StatisticsTimeType.HOUR;
+        LocalDate startDate = LocalDate.of(2023, 10, 20);
+        LocalDate endDate = LocalDate.of(2023, 10, 21);
+        StatisticsValueType valueType = StatisticsValueType.LIKE_COUNT;
+        StatisticsSortType sortType = StatisticsSortType.DESC;
+
+        PostHashtag postHashtag = mock(PostHashtag.class);
+        Post post = mock(Post.class);
+        when(postHashtag.getPost()).thenReturn(post);
+        when(post.getId()).thenReturn(1L);
+        when(hashtagRepository.findAllByHashtag(hashtag))
+                .thenReturn(List.of(postHashtag));
+
+        when(historyRepository.countsByTypeInPostIdsGroupByTimeType(any(), anyList(), any(), any(), eq(timeType)))
+                .thenReturn(Map.of("2023-10-20-02", 1L, "2023-10-21-13", 2L));
+
+        // when
+        List<StatisticsResDto> responses = statisticsService.getCountsForEachTimeByHashtag(
+                hashtag, timeType, startDate, endDate, valueType, sortType);
+
+        // then
+        Assertions.assertEquals("2023-10-21T13:00:00", responses.get(13).getTime());
+        Assertions.assertEquals("2023-10-20T02:00:00", responses.get(26).getTime());
+        Assertions.assertEquals(2L, responses.get(13).getValue());
+        Assertions.assertEquals(1L, responses.get(26).getValue());
+    }
+
+    @Test
+    @DisplayName("날짜별 통계 정보(게시물)를 불러온다.")
+    public void get_post_count_statistics_with_date() {
+        // given
+        String hashtag = "맛집";
+        StatisticsTimeType timeType = StatisticsTimeType.DATE;
+        LocalDate startDate = LocalDate.of(2023, 10, 20);
+        LocalDate endDate = LocalDate.of(2023, 10, 23);
+        StatisticsValueType valueType = StatisticsValueType.COUNT;
+        StatisticsSortType sortType = StatisticsSortType.DESC;
+
+        when(postRepository.countsByHashtagGroupByTimeType(any(), any(), any(), eq(timeType)))
+                .thenReturn(Map.of("2023-10-20", 1L, "2023-10-22", 2L));
+
+        // when
+        List<StatisticsResDto> responses = statisticsService.getCountsForEachTimeByHashtag(
+                hashtag, timeType, startDate, endDate, valueType, sortType);
+
+        // then
+        Assertions.assertEquals("2023-10-23", responses.get(0).getTime());
+        Assertions.assertEquals("2023-10-22", responses.get(1).getTime());
+        Assertions.assertEquals("2023-10-21", responses.get(2).getTime());
+        Assertions.assertEquals("2023-10-20", responses.get(3).getTime());
+        Assertions.assertEquals(0, responses.get(0).getValue());
+        Assertions.assertEquals(2L, responses.get(1).getValue());
+        Assertions.assertEquals(0, responses.get(2).getValue());
+        Assertions.assertEquals(1L, responses.get(3).getValue());
+    }
+
+    @Test
+    @DisplayName("날짜+시간별 통계 정보(게시물)를 불러온다.")
+    public void get_post_count_statistics_with_hour() {
+        // given
+        String hashtag = "맛집";
+        StatisticsTimeType timeType = StatisticsTimeType.HOUR;
+        LocalDate startDate = LocalDate.of(2023, 10, 20);
+        LocalDate endDate = LocalDate.of(2023, 10, 21);
+        StatisticsValueType valueType = StatisticsValueType.COUNT;
+        StatisticsSortType sortType = StatisticsSortType.DESC;
+
+        when(postRepository.countsByHashtagGroupByTimeType(any(), any(), any(), eq(timeType)))
+                .thenReturn(Map.of("2023-10-20-02", 1L, "2023-10-21-13", 2L));
+
+        // when
+        List<StatisticsResDto> responses = statisticsService.getCountsForEachTimeByHashtag(
+                hashtag, timeType, startDate, endDate, valueType, sortType);
+
+        // then
+        Assertions.assertEquals("2023-10-21T13:00:00", responses.get(13).getTime());
+        Assertions.assertEquals("2023-10-20T02:00:00", responses.get(26).getTime());
+        Assertions.assertEquals(2L, responses.get(13).getValue());
+        Assertions.assertEquals(1L, responses.get(26).getValue());
+    }
+
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- QueryDsl 설정 수정
- `StatisticsController` 구현
    - `GET /statistics` API 구현
    - RequestParam을 Enum으로 받기 위한 Converter 구현 및 등록
    - 날짜 관련 로직 구현
- `StatisticsService` 정의 및 구현
    - 날짜/시간 조건 및 정렬 조건에 따라 LocalDateTime 리스트 구하고 각각에 해당하는 value를 구함
- MySQL의 `DATE_FORMAT()`을 사용해 날짜/시간별 count를 구하는 쿼리 로직 구현

**TO-BE** 
- 단위 테스트 작성

### 테스트
- [x] 컨트롤러 테스트 코드
- [x] API 테스트
