### PR TITLE
feat #15 - 게시물 생성시 사용자 인증기능 추가

### DIFF
--- a/src/main/java/com/wanted/teamV/config/WebConfig.java
+++ b/src/main/java/com/wanted/teamV/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.wanted.teamV.config;
+
+import com.wanted.teamV.controller.AuthenticationPrincipalArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationPrincipalArgumentResolver);
+    }
+}

--- a/src/main/java/com/wanted/teamV/controller/PostController.java
+++ b/src/main/java/com/wanted/teamV/controller/PostController.java
@@ -1,6 +1,10 @@
 package com.wanted.teamV.controller;
 
+import com.wanted.teamV.dto.LoginMember;
 import com.wanted.teamV.dto.req.PostCreateReqDto;
+import com.wanted.teamV.entity.Member;
+import com.wanted.teamV.exception.CustomException;
+import com.wanted.teamV.repository.MemberRepository;
 import com.wanted.teamV.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -9,19 +13,37 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
+import static com.wanted.teamV.exception.ErrorCode.INVALID_REQUEST;
+
 @RestController
 @RequestMapping("/posts")
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
+    private final MemberRepository memberRepository;
 
     // 게시물 생성 API
     @PostMapping
     public ResponseEntity<Void> createPost(
+            @AuthenticationPrincipal LoginMember loginMember,
             @RequestBody PostCreateReqDto request
     ) {
+        List<String> hashtags = request.getHashtags();
+        String account = getMemberAccount(loginMember.id());
+        hashtags.add(account);
+
+        request.setHashtags(hashtags);
+
         postService.createPost(request);
         return ResponseEntity.ok().build();
+    }
+
+    private String getMemberAccount(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(INVALID_REQUEST));
+        return member.getAccount();
     }
 
 }

--- a/src/main/java/com/wanted/teamV/dto/req/PostCreateReqDto.java
+++ b/src/main/java/com/wanted/teamV/dto/req/PostCreateReqDto.java
@@ -2,10 +2,12 @@ package com.wanted.teamV.dto.req;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 public class PostCreateReqDto {
 

--- a/src/main/java/com/wanted/teamV/exception/ErrorCode.java
+++ b/src/main/java/com/wanted/teamV/exception/ErrorCode.java
@@ -6,6 +6,8 @@ public enum ErrorCode {
     NOT_FOUND(HttpStatus.BAD_REQUEST, "요청사항을 찾지 못했습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다."),
+    NO_RELATED_POSTS_FOUND(HttpStatus.NOT_FOUND, "관련 게시물이 없습니다."),
+    INVALID_PAGE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 페이지 요청입니다."),
     INVALID_AUTHENTICATION_CODE(HttpStatus.BAD_REQUEST, "인증코드가 올바르지 않습니다."),
     EXPIRE_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 토큰입니다."),


### PR DESCRIPTION
### 변경사항
**AS-IS**

- 사용자 인증 후 account 정보를 가져와 해시태그에 추가하는 로직 구현

**TO-BE** 

- 게시물 목록 조회 시 해시태그를 입력하지 않아도 사용자 account 정보를 이용하여 사용자의 게시물 가져오는 기능 구현

### 테스트
- [x] 테스트 코드
- [x] API 테스트

컨트롤러 테스트 부분에 사용자 인증 확인 추가
