### PR TITLE
test #10 - 테스트에 H2를 사용하기 위한 alias 추가

### DIFF
--- a/src/test/java/com/wanted/teamV/common/H2CustomAlias.java
+++ b/src/test/java/com/wanted/teamV/common/H2CustomAlias.java
@@ -1,0 +1,22 @@
+package com.wanted.teamV.common;
+
+import java.text.ParseException;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+public class H2CustomAlias {
+
+    public static String date_format(Date date, String mysqlFormatPattern) throws ParseException {
+        if (date == null) return null;
+        String dateFormatPattern = mysqlFormatPattern
+                .replace("%Y", "yyyy")
+                .replace("%m", "MM")
+                .replace("%d", "dd")
+                .replace("%h", "hh");
+        return date.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate().format(DateTimeFormatter.ofPattern(dateFormatPattern));
+    }
+
+}

--- a/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
+++ b/src/test/java/com/wanted/teamV/controller/StatisticsControllerTest.java
@@ -6,6 +6,7 @@ import com.wanted.teamV.dto.req.MemberApproveReqDto;
 import com.wanted.teamV.dto.req.MemberJoinReqDto;
 import com.wanted.teamV.dto.req.MemberLoginReqDto;
 import com.wanted.teamV.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,11 +34,17 @@ class StatisticsControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private ObjectMapper objectMapper;
+    @Autowired
+    private EntityManager entityManager;
 
     private String accessToken;
 
     @BeforeEach
     void setUp() throws Exception {
+        entityManager
+                .createNativeQuery("CREATE ALIAS IF NOT EXISTS date_format FOR \"com.wanted.teamV.common.H2CustomAlias.date_format\"")
+                .executeUpdate();
+
         // 회원가입
         MemberJoinReqDto joinReqDto = new MemberJoinReqDto("qwertyasdf12345", "abc@gmail.com", "qwerty1234!");
         MvcResult result = mockMvc.perform(post("/members")


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 테스트도 MySQL로만 실행 가능했음

**TO-BE** 
- 사용되는 쿼리 내에 MySQL에만 존재하는 함수(`DATE_FORMAT`)가 있어 이를 테스트시에만 H2에서 같은 역할을 하는 `FORMATDATETIME`로 변경할 수 있도록 Alias 클래스 추가
- `DATE_FORMAT`이 사용되는 테스트 클래스에 위 Alias가 적용되도록 설정 코드 추가


### 테스트
- [x] 테스트 코드
- [x] API 테스트
